### PR TITLE
Add lore option to rename command

### DIFF
--- a/src/app/commands/src/Rename.ts
+++ b/src/app/commands/src/Rename.ts
@@ -18,16 +18,22 @@ export default class Rename extends Command {
 					.setDescription("The new name")
 					.setRequired(true)
 			)
+			.addStringOption(option =>
+				option.setName("lore")
+					.setDescription("Explanation for this rename")
+					.setRequired(true)
+			)
 	}
 
 	override async execute(bot: Bot, interaction: Interaction) {
 		const target = interaction.options.getUser("target", true)
 		const newName = interaction.options.getString("name", true)
+		const lore = interaction.options.getString("lore", true)
 		const channel = interaction.channel
 		if (channel instanceof TextChannel) {
 			const targetMember = await channel.guild.members.fetch(target.id)
 			targetMember.setNickname(newName).then(() => {
-				interaction.reply("Name modified !")
+				interaction.reply(`Name modified ! Lore: ${lore}`)
 			}).catch(() => {
 				interaction.reply("Missing permissions !")
 			})	


### PR DESCRIPTION
"Summary
J’ai ajouté un nouveau champ obligatoire lore à la commande slash /rename, pour forcer la saisie d’une explication lors d’un renommage via le bot.

J’ai mis à jour l’exécution de la commande pour lire cette explication et l’inclure dans la réponse de confirmation après renommage (Name modified ! Lore: ...).

Testing

✅ npx tsc --noEmit
"
Clairement si ça compile c gucci 🧠